### PR TITLE
Upgrade of SAML2 library

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,6 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "af04a4055f2746fd260f03ab69bca0b6",
     "content-hash": "36869962d457f8fb00efa969a8656276",
     "packages": [
         {
@@ -48,7 +47,7 @@
             ],
             "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
             "homepage": "https://github.com/firebase/php-jwt",
-            "time": "2016-07-18 04:51:16"
+            "time": "2016-07-18T04:51:16+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -126,7 +125,7 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-06-19 01:22:40"
+            "time": "2017-06-19T01:22:40+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -172,7 +171,7 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2013-11-22 08:30:29"
+            "time": "2013-11-22T08:30:29+00:00"
         },
         {
             "name": "psr/log",
@@ -219,7 +218,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "robrichards/xmlseclibs",
@@ -259,7 +258,7 @@
                 "xml",
                 "xmldsig"
             ],
-            "time": "2017-05-25 15:25:34"
+            "time": "2017-05-25T15:25:34+00:00"
         },
         {
             "name": "silex/silex",
@@ -336,7 +335,7 @@
             "keywords": [
                 "microframework"
             ],
-            "time": "2017-04-30 16:26:54"
+            "time": "2017-04-30T16:26:54+00:00"
         },
         {
             "name": "simplesamlphp/saml2",
@@ -344,32 +343,36 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/simplesamlphp/saml2.git",
-                "reference": "cea679a3113d1f8198ab7d0a734de740412d0d0d"
+                "reference": "af52ace51808b6c107dfa0750a2be043b71073d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/cea679a3113d1f8198ab7d0a734de740412d0d0d",
-                "reference": "cea679a3113d1f8198ab7d0a734de740412d0d0d",
+                "url": "https://api.github.com/repos/simplesamlphp/saml2/zipball/af52ace51808b6c107dfa0750a2be043b71073d1",
+                "reference": "af52ace51808b6c107dfa0750a2be043b71073d1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-openssl": "*",
                 "ext-zlib": "*",
-                "php": ">=5.3.3",
+                "php": ">=5.4",
                 "psr/log": "~1.0",
-                "robrichards/xmlseclibs": "^2.0|^3.0"
+                "robrichards/xmlseclibs": "^3.0"
             },
             "require-dev": {
                 "mockery/mockery": "~0.9",
                 "phpmd/phpmd": "~1.5",
                 "phpunit/phpunit": "~3.7",
-                "satooshi/php-coveralls": "~0.6.1",
                 "sebastian/phpcpd": "~1.4",
                 "sensiolabs/security-checker": "~1.1",
                 "squizlabs/php_codesniffer": "~1.4"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "v3.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "SAML2\\": "src/"
@@ -389,7 +392,7 @@
                 }
             ],
             "description": "SAML2 PHP library from SimpleSAMLphp",
-            "time": "2017-06-16 08:30:57"
+            "time": "2018-01-16T11:50:28+00:00"
         },
         {
             "name": "symfony/config",
@@ -445,7 +448,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-04-12 14:07:15"
+            "time": "2017-04-12T14:07:15+00:00"
         },
         {
             "name": "symfony/debug",
@@ -501,7 +504,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01 21:01:25"
+            "time": "2017-06-01T21:01:25+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -561,7 +564,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-19 10:44:15"
+            "time": "2016-07-19T10:44:15+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -610,7 +613,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-20 05:43:46"
+            "time": "2016-07-20T05:43:46+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -663,7 +666,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-17 13:54:30"
+            "time": "2016-07-17T13:54:30+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -745,7 +748,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-07-30 09:10:37"
+            "time": "2016-07-30T09:10:37+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -804,7 +807,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 14:24:12"
+            "time": "2017-06-09T14:24:12+00:00"
         },
         {
             "name": "symfony/routing",
@@ -879,7 +882,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-06-29 05:40:00"
+            "time": "2016-06-29T05:40:00+00:00"
         },
         {
             "name": "symfony/translation",
@@ -943,7 +946,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01 20:52:29"
+            "time": "2017-06-01T20:52:29+00:00"
         },
         {
             "name": "symfony/twig-bridge",
@@ -1024,7 +1027,7 @@
             ],
             "description": "Symfony Twig Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-06-06 02:49:00"
+            "time": "2017-06-06T02:49:00+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -1073,7 +1076,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-01 20:52:29"
+            "time": "2017-06-01T20:52:29+00:00"
         },
         {
             "name": "twig/twig",
@@ -1138,7 +1141,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-06-07 18:45:17"
+            "time": "2017-06-07T18:45:17+00:00"
         }
     ],
     "packages-dev": [],

--- a/www/saml/container.php
+++ b/www/saml/container.php
@@ -3,8 +3,9 @@
 require_once __DIR__.'/../../vendor/autoload.php';
 
 use Psr\Log\LoggerInterface;
+use SAML2\Compat\AbstractContainer;
 
-class Saml2Container extends SAML2_Compat_AbstractContainer
+class Saml2Container extends AbstractContainer
 {
     /**
      * @var \Psr\Log\LoggerInterface

--- a/www/saml/index.php
+++ b/www/saml/index.php
@@ -13,7 +13,6 @@ use SAML2\AuthnRequest;
 use SAML2\Message;
 use SAML2\Binding;
 use SAML2\Compat\ContainerSingleton;
-//use SAML2\XML\saml\NameID;
 
 function newID($length = 42) {
     $id = '_';
@@ -165,7 +164,7 @@ $app->get('/sso', function (Request $request) use ($config, $app) {
 
 $app->get('/sso_return', function (Request $request) use ($config, $app) {
 
-    SAML2_Compat_ContainerSingleton::setContainer(new Saml2Container(
+    ContainerSingleton::setContainer(new Saml2Container(
         $app['monolog']
     ));
 

--- a/www/sp/container.php
+++ b/www/sp/container.php
@@ -3,8 +3,9 @@
 require_once __DIR__.'/../../vendor/autoload.php';
 
 use Psr\Log\LoggerInterface;
+use SAML2\Compat\AbstractContainer;
 
-class Saml2Container extends SAML2_Compat_AbstractContainer
+class Saml2Container extends AbstractContainer
 {
     /**
      * @var \Psr\Log\LoggerInterface


### PR DESCRIPTION
**Notes**
This PR will update the SAML2 library to the latest revision on `master`.
The application was also checked for usage of SAML2 classes using the old class name strategy.

**Remark**
Could it be usefull to lock the SAML2 library on a minimum stable version? Say `^3.1`. This might prevent BC breaking changes that can now be installed with every `composer update`?

@joostd can you review?